### PR TITLE
Amend Licence to use Java records

### DIFF
--- a/license-service/src/main/java/com/gov/zw/domain/License.java
+++ b/license-service/src/main/java/com/gov/zw/domain/License.java
@@ -3,128 +3,23 @@ package com.gov.zw.domain;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.Objects;
-
 @Document(collection = "Licenses")
-public class License {
-
-    @Id
-    private String id;
-    private String identityRef;
-    private String surname;
-    private String firstNames;
-    private String dateOfBirth;
-    private String country;
-    private String dateOfIssue;
-    private String expiryDate;
-    private String agency;
-    private String licenseNumber;
-    private String signatureImage;
-    private String address;
-
-    public License() {}
-
-    public License(String id, String identityRef, String surname, String firstNames, String dateOfBirth, String country,
-                   String dateOfIssue, String expiryDate, String agency, String licenseNumber,
-                   String signatureImage, String address) {
-        this.id = id;
-        this.identityRef = identityRef;
-        this.surname = surname;
-        this.firstNames = firstNames;
-        this.dateOfBirth = dateOfBirth;
-        this.country = country;
-        this.dateOfIssue = dateOfIssue;
-        this.expiryDate = expiryDate;
-        this.agency = agency;
-        this.licenseNumber = licenseNumber;
-        this.signatureImage = signatureImage;
-        this.address = address;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getIdentityRef() {
-        return identityRef;
-    }
-
-    public void setIdentityRef(String identityRef) {
-        this.identityRef = identityRef;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public String getFirstNames() {
-        return firstNames;
-    }
-
-    public String getDateOfBirth() {
-        return dateOfBirth;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    public String getDateOfIssue() {
-        return dateOfIssue;
-    }
-
-    public String getExpiryDate() {
-        return expiryDate;
-    }
-
-    public String getAgency() {
-        return agency;
-    }
-
-    public String getLicenseNumber() {
-        return licenseNumber;
-    }
-
-    public String getSignatureImage() {
-        return signatureImage;
-    }
-
-    public String getAddress() {
-        return address;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        License license = (License) o;
-        return Objects.equals(id, license.id) && Objects.equals(identityRef, license.identityRef) && Objects.equals(surname, license.surname) && Objects.equals(firstNames, license.firstNames) && Objects.equals(dateOfBirth, license.dateOfBirth) && Objects.equals(country, license.country) && Objects.equals(dateOfIssue, license.dateOfIssue) && Objects.equals(expiryDate, license.expiryDate) && Objects.equals(agency, license.agency) && Objects.equals(licenseNumber, license.licenseNumber) && Objects.equals(signatureImage, license.signatureImage) && Objects.equals(address, license.address);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, identityRef, surname, firstNames, dateOfBirth, country, dateOfIssue, expiryDate, agency, licenseNumber, signatureImage, address);
-    }
-
-    @Override
-    public String toString() {
-        return "License{" +
-                "id='" + id + '\'' +
-                ", identityRef='" + identityRef + '\'' +
-                ", surname='" + surname + '\'' +
-                ", firstNames='" + firstNames + '\'' +
-                ", dateOfBirth='" + dateOfBirth + '\'' +
-                ", country='" + country + '\'' +
-                ", dateOfIssue='" + dateOfIssue + '\'' +
-                ", expiryDate='" + expiryDate + '\'' +
-                ", agency='" + agency + '\'' +
-                ", licenseNumber='" + licenseNumber + '\'' +
-                ", signatureImage='" + signatureImage + '\'' +
-                ", address='" + address + '\'' +
-                '}';
+public record License(
+        @Id
+        String id,
+        String identityRef,
+        String surname,
+        String firstNames,
+        String dateOfBirth,
+        String country,
+        String dateOfIssue,
+        String expiryDate,
+        String agency,
+        String licenseNumber,
+        String signatureImage,
+        String address
+) {
+    public static License empty() {
+        return new License(null, null, null, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/license-service/src/main/java/com/gov/zw/json/LicenseJson.java
+++ b/license-service/src/main/java/com/gov/zw/json/LicenseJson.java
@@ -1,126 +1,32 @@
 package com.gov.zw.json;
 
-import java.util.Objects;
-
-public class LicenseJson {
-
-    private String id;
-    private String identityRef;
-    private String surname;
-    private String firstNames;
-    private String dateOfBirth;
-    private String country;
-    private String dateOfIssue;
-    private String expiryDate;
-    private String agency;
-    private String licenseNumber;
-    private String signatureImage;
-    private String address;
-
-    public LicenseJson() { }
-
-    public LicenseJson(String id, String identityRef, String surname, String firstNames, String dateOfBirth, String country, String dateOfIssue, String expiryDate, String agency, String licenseNumber, String signatureImage, String address) {
-        this.id = id;
-        this.identityRef = identityRef;
-        this.surname = surname;
-        this.firstNames = firstNames;
-        this.dateOfBirth = dateOfBirth;
-        this.country = country;
-        this.dateOfIssue = dateOfIssue;
-        this.expiryDate = expiryDate;
-        this.agency = agency;
-        this.licenseNumber = licenseNumber;
-        this.signatureImage = signatureImage;
-        this.address = address;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getIdentityRef() {
-        return identityRef;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public String getFirstNames() {
-        return firstNames;
-    }
-
-    public String getDateOfBirth() {
-        return dateOfBirth;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    public String getDateOfIssue() {
-        return dateOfIssue;
-    }
-
-    public String getExpiryDate() {
-        return expiryDate;
-    }
-
-    public String getAgency() {
-        return agency;
-    }
-
-    public String getLicenseNumber() {
-        return licenseNumber;
-    }
-
-    public String getSignatureImage() {
-        return signatureImage;
-    }
-
-    public String getAddress() {
-        return address;
-    }
-
-    @Override
-    public String toString() {
-        return "LicenseJson{" +
-                "id='" + id + '\'' +
-                ", identityRef='" + identityRef + '\'' +
-                ", surname='" + surname + '\'' +
-                ", firstNames='" + firstNames + '\'' +
-                ", dateOfBirth='" + dateOfBirth + '\'' +
-                ", country='" + country + '\'' +
-                ", dateOfIssue='" + dateOfIssue + '\'' +
-                ", expiryDate='" + expiryDate + '\'' +
-                ", agency='" + agency + '\'' +
-                ", licenseNumber='" + licenseNumber + '\'' +
-                ", signatureImage='" + signatureImage + '\'' +
-                ", address='" + address + '\'' +
-                '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LicenseJson that = (LicenseJson) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(identityRef, that.identityRef) &&
-                Objects.equals(surname, that.surname) &&
-                Objects.equals(firstNames, that.firstNames) &&
-                Objects.equals(dateOfBirth, that.dateOfBirth) &&
-                Objects.equals(country, that.country) &&
-                Objects.equals(dateOfIssue, that.dateOfIssue) &&
-                Objects.equals(expiryDate, that.expiryDate) &&
-                Objects.equals(agency, that.agency) &&
-                Objects.equals(licenseNumber, that.licenseNumber) &&
-                Objects.equals(signatureImage, that.signatureImage) &&
-                Objects.equals(address, that.address);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, identityRef, surname, firstNames, dateOfBirth, country, dateOfIssue, expiryDate, agency, licenseNumber, signatureImage, address);
+public record LicenseJson(
+        String id,
+        String identityRef,
+        String surname,
+        String firstNames,
+        String dateOfBirth,
+        String country,
+        String dateOfIssue,
+        String expiryDate,
+        String agency,
+        String licenseNumber,
+        String signatureImage,
+        String address
+) {
+    public static LicenseJson empty() {
+        return new LicenseJson(null, // id
+                null, // identityRef
+                null, // surname
+                null, // firstNames
+                null, // dateOfBirth
+                null, // country
+                null, //dateOfIssue
+                null, //expiryDate
+                null, // agency
+                null, //licenseNumber
+                null, // signatureImage
+                null // address
+        );
     }
 }

--- a/license-service/src/main/java/com/gov/zw/mapper/LicenseMapper.java
+++ b/license-service/src/main/java/com/gov/zw/mapper/LicenseMapper.java
@@ -30,32 +30,32 @@ public class LicenseMapper {
                         licenseJson.getLicenseNumber(),
                         licenseJson.getSignatureImage(),
                         licenseJson.getAddress()))
-                .orElse(new License());
+                .orElse(License.empty());
     }
 
     public static LicenseJson toLicenseJson(License license) {
         return Optional.ofNullable(license)
                 .map(licenseDto -> new LicenseJson(
-                        licenseDto.getId(),
-                        licenseDto.getIdentityRef(),
-                        licenseDto.getSurname(),
-                        licenseDto.getFirstNames(),
-                        licenseDto.getDateOfBirth(),
-                        licenseDto.getCountry(),
-                        licenseDto.getDateOfIssue(),
-                        licenseDto.getExpiryDate(),
-                        licenseDto.getAgency(),
-                        licenseDto.getLicenseNumber(),
-                        licenseDto.getSignatureImage(),
-                        licenseDto.getAddress()))
+                        licenseDto.id(),
+                        licenseDto.identityRef(),
+                        licenseDto.surname(),
+                        licenseDto.firstNames(),
+                        licenseDto.dateOfBirth(),
+                        licenseDto.country(),
+                        licenseDto.dateOfIssue(),
+                        licenseDto.expiryDate(),
+                        licenseDto.agency(),
+                        licenseDto.licenseNumber(),
+                        licenseDto.signatureImage(),
+                        licenseDto.address()))
                 .orElse(new LicenseJson());
     }
 
     public static List<LicenseJson> toLicenseJsonList(List<License> licenses) {
-        return Stream.of(licenses)
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
+        return Optional.ofNullable(licenses)
+                .orElseGet(List::of)
+                .stream()
                 .map(LicenseMapper::toLicenseJson)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/license-service/src/main/java/com/gov/zw/mapper/LicenseMapper.java
+++ b/license-service/src/main/java/com/gov/zw/mapper/LicenseMapper.java
@@ -18,18 +18,18 @@ public class LicenseMapper {
     public static License toLicenseDTO(LicenseJson json) {
         return Optional.ofNullable(json)
                 .map(licenseJson -> new License(
-                        licenseJson.getId(),
-                        licenseJson.getIdentityRef(),
-                        licenseJson.getSurname(),
-                        licenseJson.getFirstNames(),
-                        licenseJson.getDateOfBirth(),
-                        licenseJson.getCountry(),
-                        licenseJson.getDateOfIssue(),
-                        licenseJson.getExpiryDate(),
-                        licenseJson.getAgency(),
-                        licenseJson.getLicenseNumber(),
-                        licenseJson.getSignatureImage(),
-                        licenseJson.getAddress()))
+                        licenseJson.id(),
+                        licenseJson.identityRef(),
+                        licenseJson.surname(),
+                        licenseJson.firstNames(),
+                        licenseJson.dateOfBirth(),
+                        licenseJson.country(),
+                        licenseJson.dateOfIssue(),
+                        licenseJson.expiryDate(),
+                        licenseJson.agency(),
+                        licenseJson.licenseNumber(),
+                        licenseJson.signatureImage(),
+                        licenseJson.address()))
                 .orElse(License.empty());
     }
 
@@ -48,7 +48,7 @@ public class LicenseMapper {
                         licenseDto.licenseNumber(),
                         licenseDto.signatureImage(),
                         licenseDto.address()))
-                .orElse(new LicenseJson());
+                .orElse(LicenseJson.empty());
     }
 
     public static List<LicenseJson> toLicenseJsonList(List<License> licenses) {

--- a/license-service/src/main/java/com/gov/zw/service/LicenseServiceImpl.java
+++ b/license-service/src/main/java/com/gov/zw/service/LicenseServiceImpl.java
@@ -84,10 +84,10 @@ public class LicenseServiceImpl implements LicenseService {
     }
 
     private boolean isIdentityReferencePresent(License licenseDto) {
-        return nonNull(licenseDto.getIdentityRef());
+        return nonNull(licenseDto.identityRef());
     }
 
     private IdentityReference getLicenseIdentityReference(License license) {
-        return new IdentityReference(license.getIdentityRef());
+        return new IdentityReference(license.identityRef());
     }
 }

--- a/license-service/src/test/java/com/gov/zw/controller/LicenseControllerTest.java
+++ b/license-service/src/test/java/com/gov/zw/controller/LicenseControllerTest.java
@@ -38,6 +38,8 @@ class LicenseControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired 
+    private ObjectMapper objectMapper;
 
     @MockBean
     private LicenseService licenseServiceImpl;
@@ -47,7 +49,6 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should add a license given a valid License")
     void shouldAddALicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
         License license = new License(ID, IDENTITY_REF, SURNAME, FIRST_NAMES, DATE_OF_BIRTH, COUNTRY,
                 DATE_OF_ISSUE, EXPIRY_DATE, AGENCY, LICENSE_NUMBER,
                 SIGNATURE_IMAGE, ADDRESS);
@@ -82,8 +83,7 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should return status OK when an empty License is passed attempting to add a license")
     void shouldReturn200WhenAnEmptyLicenseIsPassedToAddLicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        License license = new License();
+        License license = License.empty();
         Map<String, String> licenseObject = objectMapper.convertValue(license, licenseTypeRef);
         JSONObject jsonObject = new JSONObject(licenseObject);
 
@@ -103,7 +103,6 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should update a License given a valid license object with updated values")
     void shouldUpdateALicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
         License license = new License(ID, IDENTITY_REF, SURNAME, FIRST_NAMES, DATE_OF_BIRTH, COUNTRY,
                 DATE_OF_ISSUE, EXPIRY_DATE, AGENCY, LICENSE_NUMBER,
                 SIGNATURE_IMAGE, ADDRESS);
@@ -119,8 +118,7 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should return HttpStatus OK when an empty license is passed when attempting to update a license")
     void shouldReturn200WhenAnEmptyLicenseIsPassedToUpdateLicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        License license = new License();
+        License license = License.empty();
         Map<String, String> licenseObject = objectMapper.convertValue(license, licenseTypeRef);
         JSONObject jsonObject = new JSONObject(licenseObject);
 
@@ -134,7 +132,6 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should delete a license given a valid license object")
     void shouldDeleteALicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
         License license = new License(ID, IDENTITY_REF, SURNAME, FIRST_NAMES, DATE_OF_BIRTH, COUNTRY,
                 DATE_OF_ISSUE, EXPIRY_DATE, AGENCY, LICENSE_NUMBER,
                 SIGNATURE_IMAGE, ADDRESS);
@@ -150,8 +147,7 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should return HttpStatus 200 when an empty license object is passed attempting to delete a license")
     void shouldReturn200WhenAnEmptyLicenseIsPassedToDeleteLicense() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        License license = new License();
+        License license = License.empty();
         Map<String, String> licenseObject = objectMapper.convertValue(license, licenseTypeRef);
         JSONObject jsonObject = new JSONObject(licenseObject);
 
@@ -177,8 +173,7 @@ class LicenseControllerTest {
     @Test
     @DisplayName("Should throw HttpStatus BAD_REQUEST when an empty license is passed attempting to get a license by identity reference")
     void shouldReturn200WhenAnEmptyLicenseIsPassedToGetLicenseByIdReference() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        License license = new License();
+        License license = License.empty();
         Map<String, String> licenseObject = objectMapper.convertValue(license, licenseTypeRef);
         JSONObject jsonObject = new JSONObject(licenseObject);
 

--- a/license-service/src/test/java/com/gov/zw/mapper/LicenseMapperTest.java
+++ b/license-service/src/test/java/com/gov/zw/mapper/LicenseMapperTest.java
@@ -58,18 +58,18 @@ class LicenseMapperTest {
         LicenseJson licenseJson = toLicenseJson(license);
 
         assertThat(licenseJson).isNotNull();
-        assertThat(licenseJson.getId()).isEqualTo(ID);
-        assertThat(licenseJson.getIdentityRef()).isEqualTo(IDENTITY_REF);
-        assertThat(licenseJson.getSurname()).isEqualTo(SURNAME);
-        assertThat(licenseJson.getFirstNames()).isEqualTo(FIRST_NAMES);
-        assertThat(licenseJson.getDateOfBirth()).isEqualTo(DATE_OF_BIRTH);
-        assertThat(licenseJson.getCountry()).isEqualTo(COUNTRY);
-        assertThat(licenseJson.getDateOfIssue()).isEqualTo(DATE_OF_ISSUE);
-        assertThat(licenseJson.getExpiryDate()).isEqualTo(EXPIRY_DATE);
-        assertThat(licenseJson.getAgency()).isEqualTo(AGENCY);
-        assertThat(licenseJson.getLicenseNumber()).isEqualTo(LICENSE_NUMBER);
-        assertThat(licenseJson.getSignatureImage()).isEqualTo(SIGNATURE_IMAGE);
-        assertThat(licenseJson.getAddress()).isEqualTo(ADDRESS);
+        assertThat(licenseJson.id()).isEqualTo(ID);
+        assertThat(licenseJson.identityRef()).isEqualTo(IDENTITY_REF);
+        assertThat(licenseJson.surname()).isEqualTo(SURNAME);
+        assertThat(licenseJson.firstNames()).isEqualTo(FIRST_NAMES);
+        assertThat(licenseJson.dateOfBirth()).isEqualTo(DATE_OF_BIRTH);
+        assertThat(licenseJson.country()).isEqualTo(COUNTRY);
+        assertThat(licenseJson.dateOfIssue()).isEqualTo(DATE_OF_ISSUE);
+        assertThat(licenseJson.expiryDate()).isEqualTo(EXPIRY_DATE);
+        assertThat(licenseJson.agency()).isEqualTo(AGENCY);
+        assertThat(licenseJson.licenseNumber()).isEqualTo(LICENSE_NUMBER);
+        assertThat(licenseJson.signatureImage()).isEqualTo(SIGNATURE_IMAGE);
+        assertThat(licenseJson.address()).isEqualTo(ADDRESS);
     }
 
     @Test
@@ -94,18 +94,18 @@ class LicenseMapperTest {
         assertThat(licenseJsonList).isNotEmpty();
         LicenseJson licenseJson = licenseJsonList.get(0);
         assertThat(licenseJson).isNotNull();
-        assertThat(licenseJson.getId()).isEqualTo(ID);
-        assertThat(licenseJson.getIdentityRef()).isEqualTo(IDENTITY_REF);
-        assertThat(licenseJson.getSurname()).isEqualTo(SURNAME);
-        assertThat(licenseJson.getFirstNames()).isEqualTo(FIRST_NAMES);
-        assertThat(licenseJson.getDateOfBirth()).isEqualTo(DATE_OF_BIRTH);
-        assertThat(licenseJson.getCountry()).isEqualTo(COUNTRY);
-        assertThat(licenseJson.getDateOfIssue()).isEqualTo(DATE_OF_ISSUE);
-        assertThat(licenseJson.getExpiryDate()).isEqualTo(EXPIRY_DATE);
-        assertThat(licenseJson.getAgency()).isEqualTo(AGENCY);
-        assertThat(licenseJson.getLicenseNumber()).isEqualTo(LICENSE_NUMBER);
-        assertThat(licenseJson.getSignatureImage()).isEqualTo(SIGNATURE_IMAGE);
-        assertThat(licenseJson.getAddress()).isEqualTo(ADDRESS);
+        assertThat(licenseJson.id()).isEqualTo(ID);
+        assertThat(licenseJson.identityRef()).isEqualTo(IDENTITY_REF);
+        assertThat(licenseJson.surname()).isEqualTo(SURNAME);
+        assertThat(licenseJson.firstNames()).isEqualTo(FIRST_NAMES);
+        assertThat(licenseJson.dateOfBirth()).isEqualTo(DATE_OF_BIRTH);
+        assertThat(licenseJson.country()).isEqualTo(COUNTRY);
+        assertThat(licenseJson.dateOfIssue()).isEqualTo(DATE_OF_ISSUE);
+        assertThat(licenseJson.expiryDate()).isEqualTo(EXPIRY_DATE);
+        assertThat(licenseJson.agency()).isEqualTo(AGENCY);
+        assertThat(licenseJson.licenseNumber()).isEqualTo(LICENSE_NUMBER);
+        assertThat(licenseJson.signatureImage()).isEqualTo(SIGNATURE_IMAGE);
+        assertThat(licenseJson.address()).isEqualTo(ADDRESS);
     }
 
     @Test

--- a/license-service/src/test/java/com/gov/zw/repository/LicenseRepositoryTest.java
+++ b/license-service/src/test/java/com/gov/zw/repository/LicenseRepositoryTest.java
@@ -53,7 +53,7 @@ class LicenseRepositoryTest {
         this.licenseRepository.save(license);
 
         List<License> licenses = this.licenseRepository.findAll();
-        Assertions.assertThat(licenses.get(4).getFirstNames()).isEqualTo("Lebron");
+        Assertions.assertThat(licenses.get(4).firstNames()).isEqualTo("Lebron");
         Assertions.assertThat(licenses.size()).isEqualTo(5);
     }
 
@@ -62,8 +62,8 @@ class LicenseRepositoryTest {
         List<License> licenses = this.licenseRepository.findAll();
 
         Assertions.assertThat(licenses.size()).isEqualTo(4);
-        Assertions.assertThat(licenses.get(0).getAgency()).isEqualTo("ZDVLA");
-        Assertions.assertThat(licenses.get(0).getDateOfBirth()).isEqualTo("28/03/1990");
+        Assertions.assertThat(licenses.get(0).agency()).isEqualTo("ZDVLA");
+        Assertions.assertThat(licenses.get(0).dateOfBirth()).isEqualTo("28/03/1990");
     }
 
     @Test
@@ -76,8 +76,8 @@ class LicenseRepositoryTest {
 
         List<License> licenses = this.licenseRepository.findAll();
         Assertions.assertThat(licenses.size()).isEqualTo(4);
-        Assertions.assertThat(licenses.get(3).getSurname()).isEqualTo("Charlie");
-        Assertions.assertThat(licenses.get(3).getFirstNames()).isEqualTo("Delta Golf");
+        Assertions.assertThat(licenses.get(3).surname()).isEqualTo("Charlie");
+        Assertions.assertThat(licenses.get(3).firstNames()).isEqualTo("Delta Golf");
     }
 
     @Test
@@ -85,7 +85,7 @@ class LicenseRepositoryTest {
         this.licenseRepository.deleteById("1");
         List<License> licenses = this.licenseRepository.findAll();
 
-        Assertions.assertThat(licenses.get(0).getFirstNames()).isEqualTo("Bravo Zulu");
+        Assertions.assertThat(licenses.get(0).firstNames()).isEqualTo("Bravo Zulu");
         Assertions.assertThat(licenses.size()).isEqualTo(3);
     }
 

--- a/license-service/src/test/java/com/gov/zw/service/LicenseServiceTest.java
+++ b/license-service/src/test/java/com/gov/zw/service/LicenseServiceTest.java
@@ -7,7 +7,6 @@ import com.gov.zw.domain.License;
 import com.gov.zw.exception.InvalidIdentityException;
 import com.gov.zw.exception.InvalidLicenseException;
 import com.gov.zw.repository.LicenseRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,15 +20,14 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class LicenseServiceTest {
 
     private static final String ID_REF = "1";
     private static final String ID = "1";
-    private static final String IDENTITY_REF = "1";
+    private static final String IDENTITY_REF = "ABC123";
     private static final String SURNAME = "Muzanenhamo";
     private static final String FIRST_NAMES = "Artemas";
     private static final String DATE_OF_BIRTH = "28/03/1990";
@@ -54,12 +52,6 @@ class LicenseServiceTest {
     private static final String LICENSE_EXCEPTION_MESSAGE = "The license is invalid!";
     private static final String IDENTITY_EXCEPTION_MESSAGE = "Identity is invalid or does not exist!";
 
-    @BeforeEach
-    void setUp() {
-        initMocks(this);
-        licenseService = new LicenseServiceImpl(identityClient, licenseRepository);
-    }
-
     @Test
     @DisplayName("Should return an identity")
     void returnIdentityByReference() throws Exception {
@@ -70,20 +62,18 @@ class LicenseServiceTest {
                 ADDRESS);
         Identity identity = new Identity(ID, IDENTITY_REF, NAME, SURNAME, BIRTH_DATE, VILLAGE_OF_ORIGIN,
                 PLACE_OF_BIRTH, DATE_OF_ISSUE);
-        IdentityReference identityReference = new IdentityReference(ID_REF);
+        IdentityReference identityReference = new IdentityReference(IDENTITY_REF);
         given(identityClient.findIdentityByIdReferenceNumber(identityReference)).willReturn(identity);
 
         licenseService.addLicense(license);
 
-        verify(identityClient, times(1)).findIdentityByIdReferenceNumber(identityReference);
+        then(identityClient).should().findIdentityByIdReferenceNumber(identityReference);
     }
 
     @Test
     @DisplayName("Should throw an InvalidIdentityException when an ID ref that is not an INT is passed")
     void throwExceptionWhenIdRefIsNotAnInt() {
-        License license = new License();
-        license.setId(ID);
-        license.setIdentityRef(IDENTITY_REF);
+        License license = new License(ID, IDENTITY_REF, null, null, null, null, null, null, null, null, null, null);
 
         InvalidIdentityException exception = assertThrows(InvalidIdentityException.class, () -> licenseService.addLicense(license));
 
@@ -93,12 +83,14 @@ class LicenseServiceTest {
     @Test
     @DisplayName("Should throw an InvalidLicenseException when license is empty")
     void throwExceptionWhenLicenseIsEmpty() {
-        License license = new License();
+        License license = License.empty();
 
         InvalidLicenseException exception = assertThrows(InvalidLicenseException.class, () -> licenseService.addLicense(license));
 
         assertThat(exception.getMessage()).isEqualTo(LICENSE_EXCEPTION_MESSAGE);
-        verify(licenseRepository, never()).save(any(License.class));
+        
+        then(identityClient).shouldHaveNoInteractions();
+        then(licenseRepository).shouldHaveNoInteractions();
     }
 
     @Test
@@ -114,30 +106,20 @@ class LicenseServiceTest {
         List<License> allLicenses = licenseService.getAllLicenses();
 
         assertThat(allLicenses).isNotEmpty();
-        License expectedLicense = allLicenses.get(0);
-        assertThat(expectedLicense.getId()).isEqualTo(ID);
-        assertThat(expectedLicense.getIdentityRef()).isEqualTo(IDENTITY_REF);
-        assertThat(expectedLicense.getSurname()).isEqualTo(SURNAME);
-        assertThat(expectedLicense.getFirstNames()).isEqualTo(FIRST_NAMES);
-        assertThat(expectedLicense.getDateOfBirth()).isEqualTo(DATE_OF_BIRTH);
-        assertThat(expectedLicense.getCountry()).isEqualTo(COUNTRY);
-        assertThat(expectedLicense.getDateOfIssue()).isEqualTo(DATE_OF_ISSUE);
-        assertThat(expectedLicense.getExpiryDate()).isEqualTo(EXPIRY_DATE);
-        assertThat(expectedLicense.getAgency()).isEqualTo(AGENCY);
-        assertThat(expectedLicense.getLicenseNumber()).isEqualTo(LICENSE_NUMBER);
-        assertThat(expectedLicense.getSignatureImage()).isEqualTo(SIGNATURE_IMAGE);
-        assertThat(expectedLicense.getAddress()).isEqualTo(ADDRESS);
-        verify(licenseRepository, times(1)).findAll();
+        assertThat(allLicenses).containsExactly(license);
+        
+        then(licenseRepository).should().findAll();
     }
 
     @Test
     @DisplayName("Should throw InvalidLicenseException when an empty license is passed")
     void throwExceptionWhenLicenseIsEmptyWhileUpdating() {
-        License license = new License();
+        License license = License.empty();
 
         assertThrows(InvalidLicenseException.class, () -> licenseService.updateLicense(license));
 
-        verify(this.licenseRepository, never()).save(any(License.class));
+        then(identityClient).shouldHaveNoInteractions();
+        then(this.licenseRepository).shouldHaveNoInteractions();
     }
 
     @Test
@@ -150,7 +132,7 @@ class LicenseServiceTest {
 
         licenseService.updateLicense(license);
 
-        verify(licenseRepository, times(1)).save(license);
+        then(licenseRepository).should().save(license);
     }
 
     @Test
@@ -163,7 +145,7 @@ class LicenseServiceTest {
 
         licenseService.removeLicense(license);
 
-        verify(licenseRepository, times(1)).delete(license);
+        then(licenseRepository).should().delete(license);
     }
 
     @Test
@@ -179,6 +161,7 @@ class LicenseServiceTest {
         License licenseByIdentityRef = licenseService.getLicenseByIdentityRef(identityReference);
 
         assertThat(licenseByIdentityRef).isEqualTo(license);
-        verify(licenseRepository, times(1)).findLicenseByIdentityRef(ID_REF);
+        
+        then(licenseRepository).should().findLicenseByIdentityRef(ID_REF);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - License and its JSON representation converted to immutable record types with a shared empty instance; public behavior preserved.
- Tests
  - Unit and integration tests updated to use the new immutable types and a centralized JSON mapper.
- Bug Fixes
  - Improved null-safety when mapping license lists and JSON to prevent errors on missing or empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->